### PR TITLE
Fix error handling in session list parsing

### DIFF
--- a/lib/Calvin/Bots/Cambot.pm
+++ b/lib/Calvin/Bots/Cambot.pm
@@ -57,13 +57,19 @@ sub parse_session_list {
 
     # Parse the arguments.  Anything not an option should be thrown away
     # normally, but if we didn't succeed it can be used for error message.
-    my ($success, $remaining_args) = GetOptionsFromString($request, \%args,
-                                                          @options);
+    # Suppress reporting of errors, since this is some sort of user problem
+    # and will be reported directly to the user.
+    my ($success, $remaining_args);
+    {
+        local $SIG{__WARN__} = sub {};
+        ($success, $remaining_args)
+          = GetOptionsFromString($request, \%args, @options);
+    }
     if (! $success) {
         my $error = "Problem parsing list request at '" .
                     join (' ', @{$remaining_args}) . "'";
         $client->msg ($user, $error);
-        return undef;
+        return;
     }
 
     # Now do a little jiggering of the values for mutually exclusive defaults.


### PR DESCRIPTION
If GetOptionsFromString returned an error, parse_session_list
returned an explicit undef, which isn't treated as an empty hash
and resulted in errors like this:

```
Apr 29 19:06:23 haven uberbot[317]: Odd number of elements in hash assignment at /usr/share/perl5/Calvin/Bots/Cambot.pm line 536.
Apr 29 19:06:23 haven uberbot[317]: Use of uninitialized value in list assignment at /usr/share/perl5/Calvin/Bots/Cambot.pm line 536.
```

The error from GetOptionsFromString was also reported to standard
error.  Suppress that with a __WARN__ handler and use a bare return
to return an empty list.